### PR TITLE
Properly set infoLog length

### DIFF
--- a/src/_1_getting_started/_2_1_hello_triangle.rs
+++ b/src/_1_getting_started/_2_1_hello_triangle.rs
@@ -67,10 +67,11 @@ pub fn main_1_2_1() {
         // check for shader compile errors
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(512);
-        infoLog.set_len(512 - 1); // subtract 1 to skip the trailing null character
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         gl::GetShaderiv(vertexShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(vertexShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(vertexShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -82,7 +83,8 @@ pub fn main_1_2_1() {
         // check for shader compile errors
         gl::GetShaderiv(fragmentShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(fragmentShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(fragmentShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -94,7 +96,8 @@ pub fn main_1_2_1() {
         // check for linking errors
         gl::GetProgramiv(shaderProgram, gl::LINK_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetProgramInfoLog(shaderProgram, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetProgramInfoLog(shaderProgram, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::PROGRAM::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
         gl::DeleteShader(vertexShader);

--- a/src/_1_getting_started/_2_2_hello_triangle_indexed.rs
+++ b/src/_1_getting_started/_2_2_hello_triangle_indexed.rs
@@ -67,10 +67,11 @@ pub fn main_1_2_2() {
         // check for shader compile errors
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(512);
-        infoLog.set_len(512 - 1); // subtract 1 to skip the trailing null character
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         gl::GetShaderiv(vertexShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(vertexShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(vertexShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -82,7 +83,8 @@ pub fn main_1_2_2() {
         // check for shader compile errors
         gl::GetShaderiv(fragmentShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(fragmentShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(fragmentShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -94,7 +96,8 @@ pub fn main_1_2_2() {
         // check for linking errors
         gl::GetProgramiv(shaderProgram, gl::LINK_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetProgramInfoLog(shaderProgram, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetProgramInfoLog(shaderProgram, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::PROGRAM::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
         gl::DeleteShader(vertexShader);

--- a/src/_1_getting_started/_2_3_hello_triangle_exercise1.rs
+++ b/src/_1_getting_started/_2_3_hello_triangle_exercise1.rs
@@ -67,10 +67,11 @@ pub fn main_1_2_3() {
         // check for shader compile errors
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(512);
-        infoLog.set_len(512 - 1); // subtract 1 to skip the trailing null character
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         gl::GetShaderiv(vertexShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(vertexShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(vertexShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -82,7 +83,8 @@ pub fn main_1_2_3() {
         // check for shader compile errors
         gl::GetShaderiv(fragmentShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(fragmentShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(fragmentShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -94,7 +96,8 @@ pub fn main_1_2_3() {
         // check for linking errors
         gl::GetProgramiv(shaderProgram, gl::LINK_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetProgramInfoLog(shaderProgram, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetProgramInfoLog(shaderProgram, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::PROGRAM::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
         gl::DeleteShader(vertexShader);

--- a/src/_1_getting_started/_2_4_hello_triangle_exercise2.rs
+++ b/src/_1_getting_started/_2_4_hello_triangle_exercise2.rs
@@ -67,10 +67,11 @@ pub fn main_1_2_4() {
         // check for shader compile errors
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(512);
-        infoLog.set_len(512 - 1); // subtract 1 to skip the trailing null character
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         gl::GetShaderiv(vertexShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(vertexShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(vertexShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -82,7 +83,8 @@ pub fn main_1_2_4() {
         // check for shader compile errors
         gl::GetShaderiv(fragmentShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(fragmentShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(fragmentShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -94,7 +96,8 @@ pub fn main_1_2_4() {
         // check for linking errors
         gl::GetProgramiv(shaderProgram, gl::LINK_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetProgramInfoLog(shaderProgram, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetProgramInfoLog(shaderProgram, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::PROGRAM::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
         gl::DeleteShader(vertexShader);

--- a/src/_1_getting_started/_3_1_shaders_uniform.rs
+++ b/src/_1_getting_started/_3_1_shaders_uniform.rs
@@ -68,10 +68,11 @@ pub fn main_1_3_1() {
         // check for shader compile errors
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(512);
-        infoLog.set_len(512 - 1); // subtract 1 to skip the trailing null character
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         gl::GetShaderiv(vertexShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(vertexShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(vertexShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -83,7 +84,8 @@ pub fn main_1_3_1() {
         // check for shader compile errors
         gl::GetShaderiv(fragmentShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(fragmentShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(fragmentShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -95,7 +97,8 @@ pub fn main_1_3_1() {
         // check for linking errors
         gl::GetProgramiv(shaderProgram, gl::LINK_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetProgramInfoLog(shaderProgram, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetProgramInfoLog(shaderProgram, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::PROGRAM::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
         gl::DeleteShader(vertexShader);

--- a/src/_1_getting_started/_3_2_shaders_interpolation.rs
+++ b/src/_1_getting_started/_3_2_shaders_interpolation.rs
@@ -71,10 +71,11 @@ pub fn main_1_3_2() {
         // check for shader compile errors
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(512);
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         gl::GetShaderiv(vertexShader, gl::COMPILE_STATUS, &mut success);
-        infoLog.set_len(512 - 1); // subtract 1 to skip the trailing null character
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(vertexShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(vertexShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -86,7 +87,8 @@ pub fn main_1_3_2() {
         // check for shader compile errors
         gl::GetShaderiv(fragmentShader, gl::COMPILE_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetShaderInfoLog(fragmentShader, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetShaderInfoLog(fragmentShader, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
 
@@ -98,7 +100,8 @@ pub fn main_1_3_2() {
         // check for linking errors
         gl::GetProgramiv(shaderProgram, gl::LINK_STATUS, &mut success);
         if success != gl::TRUE as GLint {
-            gl::GetProgramInfoLog(shaderProgram, 512, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+            gl::GetProgramInfoLog(shaderProgram, 512, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+            infoLog.set_len(*infoLogLenPtr as usize);
             println!("ERROR::SHADER::PROGRAM::COMPILATION_FAILED\n{}", str::from_utf8(&infoLog).unwrap());
         }
         gl::DeleteShader(vertexShader);

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -102,11 +102,12 @@ impl Shader {
     unsafe fn checkCompileErrors(&self, shader: u32, type_: &str) {
         let mut success = gl::FALSE as GLint;
         let mut infoLog = Vec::with_capacity(1024);
-        infoLog.set_len(1024 - 1); // subtract 1 to skip the trailing null character
+        let infoLogLenPtr = &mut 0 as *mut GLsizei;
         if type_ != "PROGRAM" {
             gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut success);
             if success != gl::TRUE as GLint {
-                gl::GetShaderInfoLog(shader, 1024, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+                gl::GetShaderInfoLog(shader, 1024, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+                infoLog.set_len(*infoLogLenPtr as usize);
                 println!("ERROR::SHADER_COMPILATION_ERROR of type: {}\n{}\n \
                           -- --------------------------------------------------- -- ",
                          type_,
@@ -116,7 +117,8 @@ impl Shader {
         } else {
             gl::GetProgramiv(shader, gl::LINK_STATUS, &mut success);
             if success != gl::TRUE as GLint {
-                gl::GetProgramInfoLog(shader, 1024, ptr::null_mut(), infoLog.as_mut_ptr() as *mut GLchar);
+                gl::GetProgramInfoLog(shader, 1024, infoLogLenPtr, infoLog.as_mut_ptr() as *mut GLchar);
+                infoLog.set_len(*infoLogLenPtr as usize);
                 println!("ERROR::PROGRAM_LINKING_ERROR of type: {}\n{}\n \
                           -- --------------------------------------------------- -- ",
                          type_,


### PR DESCRIPTION
`gl::GetShaderInfoLog` will fill the first half of the `infoLog` buffer with valid utf8 data, but the second half of the buffer could be anything. This leads to `str::from_utf8(&infoLog).unwrap()` sometimes working and sometimes panicking depending on what is in that region of memory when `infoLog` is allocated.

Can close https://github.com/bwasty/learn-opengl-rs/issues/16 when this is merged.